### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you want to help contribute to the framework, check out the [Framework Specs]
 
 ## Build & Test
 
-[Golang 1.20+](https://go.dev/doc/install) and [Foundry](https://book.getfoundry.sh/getting-started/installation) are required for Polaris.
+[Golang 1.21+](https://go.dev/doc/install) and [Foundry](https://book.getfoundry.sh/getting-started/installation) are required for Polaris.
 
 1. Install [go 1.21+ from the official site](https://go.dev/dl/) or the method of your choice. Ensure that your `GOPATH` and `GOBIN` environment variables are properly set up by using the following commands:
 


### PR DESCRIPTION
A potential inconsistency in Golang versions mentioned: "Golang 1.20+" is required as stated initially, but later, it specifies to install "go 1.21+ from the official site." This might confuse users about the minimum required version.